### PR TITLE
Add checkbox to allow players to swap marks on game restart

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,11 @@
                     </div>
                 </div>
 
+                			<div class="form-section swap-marks-section">
+				<label for="swap-marks-input">Swap marks on game restart:</label>
+				<input type="checkbox" name="swap-marks" id="swap-marks-input" class="swap-marks-input">
+			</div>
+
                 <div class="game-results" hidden>
                     <label for="winner-name-input">Winner</label>
                     <input type="text" name="winner-name" id="winner-name-input" disabled maxlength="15">

--- a/script.js
+++ b/script.js
@@ -582,4 +582,21 @@ const main = function () {
     })();
 
     DisplayController.displayNewGameScreen();
+
+    	// Handle swap marks checkbox
+	const swapMarksCheckbox = document.querySelector(".swap-marks-input");
+	if (swapMarksCheckbox) {
+		const originalDoOnNewGame = doOnNewGame;
+		const wrappedDoOnNewGame = () => {
+			const shouldSwap = swapMarksCheckbox.checked;
+			originalDoOnNewGame();
+			if (shouldSwap && Game.getFirstPlayingMark && playerNameInputs.length === 2) {
+				// Swap the player name inputs in the DOM to reflect swapped marks
+				const temp = playerNameInputs[0].value;
+				playerNameInputs[0].value = playerNameInputs[1].value;
+				playerNameInputs[1].value = temp;
+			}
+		};
+		doOnNewGame = wrappedDoOnNewGame;
+	}
 }();


### PR DESCRIPTION
This PR implements the feature requested in issue #7: Allow players to swap marks on game restart.

## Changes:
1. Added a checkbox input in the HTML form to allow users to enable mark swapping
2. Implemented JavaScript logic to swap player names when the checkbox is checked during game restart

## How it works:
When a player checks the "Swap marks on game restart" checkbox and starts a new game, the player marks will be swapped - Player 1 will play with Player 2's mark and vice versa.

Closes #7